### PR TITLE
bugfix in DefaultFileObjectConverter & implement urlencoding of passwd and username 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ How to include the artifact in your project:
     <dependency>
       <groupId>com.github.fracpete</groupId>
       <artifactId>vfsjfilechooser2</artifactId>
-      <version>0.2.8</version>
+      <version>0.2.9</version>
     </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,16 @@
       <version>4.13.1</version>
       <scope>test</scope>      
     </dependency>
-<dependency>
-    <groupId>com.hierynomus</groupId>
-    <artifactId>sshj</artifactId>
-    <version>0.27.0</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/commons-net/commons-net -->
-<dependency>
-    <groupId>commons-net</groupId>
-    <artifactId>commons-net</artifactId>
-    <version>3.7.2</version>
-</dependency>
+	<dependency>
+	    <groupId>com.hierynomus</groupId>
+	    <artifactId>sshj</artifactId>
+	    <version>0.27.0</version>
+	</dependency>
+	<dependency>
+	    <groupId>commons-net</groupId>
+	    <artifactId>commons-net</artifactId>
+	    <version>3.7.2</version>
+	</dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,17 @@
       <version>4.13.1</version>
       <scope>test</scope>      
     </dependency>
-
+<dependency>
+    <groupId>com.hierynomus</groupId>
+    <artifactId>sshj</artifactId>
+    <version>0.27.0</version>
+</dependency>
+<!-- https://mvnrepository.com/artifact/commons-net/commons-net -->
+<dependency>
+    <groupId>commons-net</groupId>
+    <artifactId>commons-net</artifactId>
+    <version>3.7.2</version>
+</dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
-      <type>jar</type>
+      <scope>test</scope>      
     </dependency>
 
     <dependency>
@@ -102,6 +102,16 @@
       <artifactId>commons-io</artifactId>
       <version>2.1</version>
     </dependency>
+    <dependency>
+        <groupId>commons-httpclient</groupId>
+        <artifactId>commons-httpclient</artifactId>
+        <version>3.1</version>
+    </dependency>
+    <dependency>
+    	<groupId>com.jcraft</groupId>
+    	<artifactId>jsch</artifactId>
+    	<version>0.1.50</version>
+	</dependency>
   </dependencies>
 
   <profiles>
@@ -179,8 +189,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/googlecode/vfsjfilechooser2/accessories/bookmarks/BookmarksEditorPanel.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/accessories/bookmarks/BookmarksEditorPanel.java
@@ -33,6 +33,8 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.text.NumberFormat;
 import java.text.ParseException;
 
@@ -169,11 +171,21 @@ public final class BookmarksEditorPanel extends JPanel {
 				}
 
 				if (parser.getUsername() != null) {
-					usernameTextField.setText(parser.getUsername());
+					try {
+						usernameTextField.setText(URLDecoder.decode(parser.getUsername(),"UTF-8"));
+					} catch (UnsupportedEncodingException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
 				}
 
 				if (parser.getPassword() != null) {
-					passwordTextField.setText(parser.getPassword());
+					try {
+						passwordTextField.setText(URLDecoder.decode(parser.getPassword(),"UTF-8"));
+					} catch (UnsupportedEncodingException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
 				}
 			}
 
@@ -395,29 +407,35 @@ public final class BookmarksEditorPanel extends JPanel {
 
 				Credentials credentials = credentialsBuilder.build();
 
-				String uri = credentials.toFileObjectURL();
+				String uri;
+				try {
+					uri = credentials.toFileObjectURL();
 
-		 		//sl start		
-				VFSURIValidator v = new VFSURIValidator();
-				if(! v.isValid(uri)){
-					//popup a warning 
-					JOptionPane.showMessageDialog(null,VFSResources.getMessage("VFSFileChooser.errBADURI"));
-					//System.out.println("BookmarksEditorPanel -- bad uri="+uri+"=");
+			 		//sl start		
+					VFSURIValidator v = new VFSURIValidator();
+					if(! v.isValid(uri)){
+						//popup a warning 
+						JOptionPane.showMessageDialog(null,VFSResources.getMessage("VFSFileChooser.errBADURI"));
+						//System.out.println("BookmarksEditorPanel -- bad uri="+uri+"=");
+					}
+					else {
+						//System.out.println("BookmarksEditorPanel -- good uri="+uri+"=");
+					}
+			 		//sl stop		
+					if (editIndex == -1) {
+						bookmarks.add(new TitledURLEntry(bookmarkName, uri));
+					} else {
+						bookmarks.setValueAt(bookmarkName, editIndex, 0);
+						bookmarks.setValueAt(uri, editIndex, 1);
+					}
+	
+					bookmarks.save(); // sl
+	
+					parentDialog.restoreDefaultView();
+				} catch (UnsupportedEncodingException e1) {
+					// TODO Auto-generated catch block
+					e1.printStackTrace();
 				}
-				else {
-					//System.out.println("BookmarksEditorPanel -- good uri="+uri+"=");
-				}
-		 		//sl stop		
-				if (editIndex == -1) {
-					bookmarks.add(new TitledURLEntry(bookmarkName, uri));
-				} else {
-					bookmarks.setValueAt(bookmarkName, editIndex, 0);
-					bookmarks.setValueAt(uri, editIndex, 1);
-				}
-
-				bookmarks.save(); // sl
-
-				parentDialog.restoreDefaultView();
 			}
 		});
 

--- a/src/main/java/com/googlecode/vfsjfilechooser2/accessories/connection/Credentials.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/accessories/connection/Credentials.java
@@ -19,6 +19,8 @@
  */
 package com.googlecode.vfsjfilechooser2.accessories.connection;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * Representation of users credentials
@@ -55,8 +57,9 @@ public class Credentials
 
     /**
      * @return the complete path of the directory to browse
+     * @throws UnsupportedEncodingException 
      */
-    public String toFileObjectURL()
+    public String toFileObjectURL() throws UnsupportedEncodingException
     {
         StringBuilder sb = new StringBuilder();
 
@@ -65,37 +68,21 @@ public class Credentials
 
         if (!protocol.toLowerCase().equals("file"))
         {
-            if (!("".equals(username.trim())))
-            {
-                sb.append(this.username);
-
-                if (password.length != 0)
-                {
+            if (!("".equals(username.trim()))) {
+                sb.append(URLEncoder.encode(this.username,"UTF-8"));                
+                String pwd = new String(password);
+                if (pwd.length()>0) {
                     sb.append(":");
-		    for (int i = 0; i < this.password.length; i++)
-		    {
-		        if (this.password[i] == '@')
-			{
-			    sb.append("%40");
-			}
-		        else
-			{
-			    sb.append(this.password[i]);
-			}
-		    }
+                    sb.append(URLEncoder.encode(pwd,"UTF-8"));
                 }
-
                 sb.append("@");
             }
-
             sb.append(this.hostname);
-
             if (port != -1)
             {
                 sb.append(":").append(this.port);
             }
         }
-
         return sb.append(defaulRemotetPath).toString();
     }
 

--- a/src/main/java/com/googlecode/vfsjfilechooser2/demo/TestDownloadFTP.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/demo/TestDownloadFTP.java
@@ -1,0 +1,81 @@
+/**
+ * 
+ */
+package com.googlecode.vfsjfilechooser2.demo;
+
+import java.net.URL;
+import java.net.URLEncoder;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.ftp.FtpFileSystemConfigBuilder;
+import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystem;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.RETURN_TYPE;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.SELECTION_MODE;
+import com.googlecode.vfsjfilechooser2.accessories.DefaultAccessoriesPanel;
+import com.googlecode.vfsjfilechooser2.utils.VFSUtils;
+
+/**
+ * @author f3thomas
+ *
+ * created 08.01.2021
+ */
+
+public class TestDownloadFTP {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// TODO Test 08.01.2021
+		TestDownloadFTP ts=new TestDownloadFTP();
+		ts.start();
+	}
+	// TODO Test 08.01.2021
+	private void start() {
+		
+		String protocoll = "ftp";
+		Integer port = 21;
+		String remoteHost = "myftpserver.mydomain.at";
+		String password = "changeIT";
+		String username = "changeIT";		
+		String remoteFile="/tom";
+		
+
+		try {
+			FileSystemOptions options= new FileSystemOptions();
+			FtpFileSystemConfigBuilder.getInstance().setUserDirIsRoot(options, false);
+			FtpFileSystemConfigBuilder.getInstance().setPassiveMode(options, true);
+			
+			FileSystemManager manager = VFS.getManager();
+		    FileObject local = manager.resolveFile(System.getProperty("user.dir") + "/" + "temp_"  + "vfsFile.pdf");
+		    FileObject local2 = manager.resolveFile(System.getProperty("user.dir") + "/" + "temp_"  + "vfsFile2FTP4.pdf");
+		    System.out.println(local.getURL());
+		    FileObject remote = manager.resolveFile("ftp://" + username + ":" + password + "@" + remoteHost + "/" + remoteFile,options);
+		    remote.copyFrom(local, Selectors.SELECT_SELF);
+		    local2.copyFrom(remote, Selectors.SELECT_SELF);
+		    local2.close();
+		    local.close();
+		    remote.close();
+		    
+		    
+		    System.out.println("hat funktioniert ");
+//		
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		}
+		
+	}
+}

--- a/src/main/java/com/googlecode/vfsjfilechooser2/demo/TestDownloadSFTP.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/demo/TestDownloadSFTP.java
@@ -1,0 +1,75 @@
+/**
+ * 
+ */
+package com.googlecode.vfsjfilechooser2.demo;
+
+import java.net.URL;
+import java.net.URLEncoder;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystem;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.RETURN_TYPE;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.SELECTION_MODE;
+import com.googlecode.vfsjfilechooser2.accessories.DefaultAccessoriesPanel;
+import com.googlecode.vfsjfilechooser2.utils.VFSUtils;
+
+/**
+ * @author f3thomas
+ *
+ * created 08.01.2021
+ */
+
+public class TestDownloadSFTP {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// TODO Test 08.01.2021
+		TestDownloadSFTP ts=new TestDownloadSFTP();
+		ts.start();
+	}
+	// TODO Test 08.01.2021
+	private void start() {
+		
+		String protocoll = "sftp";
+		Integer port = 22;
+		String remoteHost = "mysftpserver.mydomain.at";
+		String password = "changeIT";
+		String username = "changeIT";		
+		String remoteFile="/tomtest/tomtestfile.txt";
+		
+		try {
+			
+			FileSystemManager manager = VFS.getManager();
+		    FileObject local = manager.resolveFile(System.getProperty("user.dir") + "/" + "temp_"  + "vfsFile.pdf");
+		    FileObject local2 = manager.resolveFile(System.getProperty("user.dir") + "/" + "temp_"  + "vfsFile2FTP4.pdf");
+		    FileObject remote = manager.resolveFile("sftp://" + username + ":" + password + "@" + remoteHost + "/" + remoteFile);
+		    remote.copyFrom(local, Selectors.SELECT_SELF);
+		    local2.copyFrom(remote, Selectors.SELECT_SELF);
+		    local2.close();
+		    local.close();
+		    remote.close();
+		    
+		    
+		    System.out.println("hat funktioniert ");
+//		
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		}
+		
+	}
+}

--- a/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomBrowserFTP.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomBrowserFTP.java
@@ -1,0 +1,95 @@
+/**
+ * 
+ */
+package com.googlecode.vfsjfilechooser2.demo;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.ftp.FtpFileObject;
+import org.apache.commons.vfs2.provider.ftp.FtpFileSystemConfigBuilder;
+import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystem;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.RETURN_TYPE;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.SELECTION_MODE;
+import com.googlecode.vfsjfilechooser2.accessories.DefaultAccessoriesPanel;
+import com.googlecode.vfsjfilechooser2.utils.FileObjectConverter;
+import com.googlecode.vfsjfilechooser2.utils.VFSUtils;
+
+/**
+ * @author f3thomas
+ *
+ * created 08.01.2021
+ */
+
+public class TomBrowserFTP {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// TODO Test 08.01.2021
+		TomBrowserFTP ts=new TomBrowserFTP();
+		ts.start();
+	}
+	// TODO Test 08.01.2021
+	private void start() {
+		
+		String protocoll = "ftp";
+		Integer port = 21;
+		
+		String remoteHost = "myftpserver.mydomain.at";
+		String password = "changeIT";
+		String username = "changeIT";			
+		String path="/tomFolder";
+	
+		try {
+			String userInfo = URLEncoder.encode(username,"UTF-8") + ":" + URLEncoder.encode(password,"UTF-8");
+			URI uri=new URI(protocoll, userInfo, remoteHost, port,path);
+			// create a file chooser
+//			VFS.setUriStyle(false);
+			FileSystemManager manager =VFS.getManager();
+			FileSystemOptions options= new FileSystemOptions();
+			FtpFileSystemConfigBuilder.getInstance().setUserDirIsRoot(options, false);
+			FtpFileSystemConfigBuilder.getInstance().setPassiveMode(options, true);
+			FileObject remote = manager.resolveFile(uri.toString(),options);
+			FileObject[] children = remote.getChildren();
+			VFSJFileChooser fileChooser = new VFSJFileChooser(remote);
+			fileChooser.setAccessory(new DefaultAccessoriesPanel(fileChooser));
+			fileChooser.setFileHidingEnabled(false);
+			fileChooser.setMultiSelectionEnabled(false);
+			fileChooser.setFileSelectionMode(SELECTION_MODE.FILES_ONLY);
+//			fileChooser.setFileSelectionMode(SELECTION_MODE.FILES_AND_DIRECTORIES);
+			// show the file dialog
+			System.out.println("jetzt wird filechooser aufgerufen:");
+			RETURN_TYPE answer = fileChooser.showOpenDialog(null);
+			
+			// check if a file was selected
+			if (answer == RETURN_TYPE.APPROVE)
+			{
+				final FileObject aFileObject = fileChooser.getSelectedFileObject();
+				
+				// remove authentication credentials from the file path
+				final String safeName = VFSUtils.getFriendlyName(aFileObject.toString());
+				
+				System.out.printf("%s %s", "You selected:", safeName);
+			}
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomBrowserSFTP.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomBrowserSFTP.java
@@ -1,0 +1,95 @@
+/**
+ * 
+ */
+package com.googlecode.vfsjfilechooser2.demo;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.ftp.FtpFileObject;
+import org.apache.commons.vfs2.provider.sftp.SftpFileProvider;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystem;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.RETURN_TYPE;
+import com.googlecode.vfsjfilechooser2.VFSJFileChooser.SELECTION_MODE;
+import com.googlecode.vfsjfilechooser2.accessories.DefaultAccessoriesPanel;
+import com.googlecode.vfsjfilechooser2.utils.VFSUtils;
+
+/**
+ * @author f3thomas
+ *
+ * created 08.01.2021
+ */
+
+public class TomBrowserSFTP {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// TODO Test 08.01.2021
+		TomBrowserSFTP ts=new TomBrowserSFTP();
+		ts.start();
+	}
+	// TODO Test 08.01.2021
+	private void start() {
+
+		String protocoll = "sftp";
+		Integer port = 22;
+		
+		String remoteHost = "myftpserver.mydomain.at";
+		String password = "changeIT";
+		String username = "changeIT";		
+		String path="/tomtest";
+	
+		try {
+			String userInfo = URLEncoder.encode(username,"UTF-8") + ":" + URLEncoder.encode(password,"UTF-8");
+//			String userInfo =URLEncoder.encode(passwd,"UTF-8") + ":" + URLEncoder.encode(user,"UTF-8") ;
+			URI uri=new URI(protocoll, userInfo, remoteHost, port,path);
+			// create a file chooser
+			FileSystemManager manager = VFS.getManager();
+			FileObject remote = manager.resolveFile(uri.toString());
+			System.out.println("remoteExists:" + VFSUtils.exists(remote));
+			VFSJFileChooser fileChooser = new VFSJFileChooser();
+		    fileChooser.setCurrentDirectoryObject(remote);
+		    
+			// configure the file dialog
+//			fileChooser.setAccessory(new DefaultAccessoriesPanel(fileChooser));
+			fileChooser.setFileHidingEnabled(false);
+			fileChooser.setMultiSelectionEnabled(false);
+			fileChooser.setFileSelectionMode(SELECTION_MODE.FILES_ONLY);
+//			fileChooser.setFileSelectionMode(SELECTION_MODE.FILES_AND_DIRECTORIES);
+			fileChooser.setCurrentDirectoryObject(remote);			
+			// show the file dialog
+			System.out.println("jetzt wird filechooseraufgerufen:");
+			
+			RETURN_TYPE answer = fileChooser.showOpenDialog(null);
+			
+			// check if a file was selected
+			if (answer == RETURN_TYPE.APPROVE)
+			{
+				final FileObject aFileObject = fileChooser.getSelectedFileObject();
+				
+				// remove authentication credentials from the file path
+				final String safeName = VFSUtils.getFriendlyName(aFileObject.toString());
+				
+				System.out.printf("%s %s", "You selected:", safeName);
+			}
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomDownloadSSHClient.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/demo/TomDownloadSSHClient.java
@@ -1,0 +1,81 @@
+/**
+ * 
+ */
+package com.googlecode.vfsjfilechooser2.demo;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.commons.vfs2.provider.UriParser;
+
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
+
+/**
+ * @author f3thomas
+ *
+ * created 08.01.2021
+ */
+
+public class TomDownloadSSHClient {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// TODO Test 08.01.2021
+		TomDownloadSSHClient ts=new TomDownloadSSHClient();
+		ts.start();
+	}
+	// TODO Test 08.01.2021
+	private void start() {
+		
+		String protocoll = "sftp";
+		Integer port = 22;
+	
+		
+		String remoteHost = "myftpserver.mydomain.at";
+		String password = "changeIT";
+		String username = "changeIT";			
+		
+		String localpath=System.getProperty("user.dir") + "/" + "temp_" + "vfsFile.pdf";
+//		String path="/ALLE/Adjustment/H350_30B/Adjustment_de-de/Programme/01_Squaring.f4g";
+//		String path="/ALLE/Adjustment/H350_30B/Adjustment_de-de/Programme/F4Integrate Overview for Techs1_GER.pdf";
+//		String path="/ALLE/Adjustment/H350_30B/Adjustment_de-de/Programme/F4Integrate Overview for Techs1_GER.pdf";
+		
+		String path = "/root/hallo tom.test";
+		
+		try {
+//		    path=URIUtil.encodePath(path);
+//            path=path.replaceAll("%20"," ");
+//		    path = "\"" + path + "\"";
+		    System.out.println(path);
+			SSHClient sshClient = setupSshj(remoteHost,username,password);
+		    SFTPClient sftpClient = sshClient.newSFTPClient();
+		    String remoteFile = path;
+		    System.out.println("TomDownload2.start() von: " + remoteFile + "    ->   " + localpath );
+		    sftpClient.get(remoteFile, localpath);
+		 
+		    sftpClient.close();
+		    sshClient.disconnect();
+		    
+		    
+		    
+		    
+
+		} catch (Exception e) {
+			// TODO: handle exception
+			e.printStackTrace();
+		}
+	}
+	private SSHClient setupSshj(String remoteHost,String username,String password) throws IOException {
+	    SSHClient client = new SSHClient();
+	    client.addHostKeyVerifier(new PromiscuousVerifier());
+	    client.connect(remoteHost);
+	    client.authPassword(username, password);
+	    return client;
+	}
+
+}

--- a/src/main/java/com/googlecode/vfsjfilechooser2/utils/DefaultFileObjectConverter.java
+++ b/src/main/java/com/googlecode/vfsjfilechooser2/utils/DefaultFileObjectConverter.java
@@ -22,6 +22,7 @@ package com.googlecode.vfsjfilechooser2.utils;
 import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
+import java.net.URL;
 
 import org.apache.commons.vfs2.FileObject;
 
@@ -48,7 +49,7 @@ public class DefaultFileObjectConverter
     if (file == null)
 	return null;
     try {
-      return new File(new URI(file.getName().getURI().replace(" ", "%20")));
+      return new File(new URI(file.getName().getURI().replace(" ", "%20")).toString());
     }
     catch (Exception e) {
       System.err.println("Failed to convert '" + file + "' into file!");


### PR DESCRIPTION
1. for ftpFileObjects we have to use new File(new URI(file.getName().getURI().replace(" ", "%20")).toString()) instead of new File(new URI(file.getName().getURI().replace(" ", "%20"))); (seems to be a Java bug)
2. add urlencoding of the password and username
3.  add Examples for FTP and SFTP usage
4. 
